### PR TITLE
[config]: Stop Vercel preview builds for Dependabot, increase Dependabot PR count from 5 to 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10 # number of open pull requests
     commit-message:
       # Prefix all messages with dependencies tag
       prefix: "[dependencies]: "

--- a/vercel_ignored_build_step.sh
+++ b/vercel_ignored_build_step.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+DEPENDABOT_AUTHOR_NAME="dependabot[bot]"
+echo "VERCEL_ENV: $VERCEL_ENV"
+echo "VERCEL_GIT_COMMIT_AUTHOR_LOGIN: $VERCEL_GIT_COMMIT_AUTHOR_LOGIN"
+
+if [[ "$VERCEL_GIT_COMMIT_AUTHOR_LOGIN" == "$DEPENDABOT_AUTHOR_NAME" ]] ; then
+  # Skip all builds authored by dependabot
+  echo "🛑 - Build cancelled"
+  exit 0;
+else
+  # Proceed with build otherwise
+  echo "✅ - Build can proceed"
+  exit 1;
+fi

--- a/vercel_ignored_build_step.sh
+++ b/vercel_ignored_build_step.sh
@@ -6,10 +6,10 @@ echo "VERCEL_GIT_COMMIT_AUTHOR_LOGIN: $VERCEL_GIT_COMMIT_AUTHOR_LOGIN"
 
 if [[ "$VERCEL_GIT_COMMIT_AUTHOR_LOGIN" == "$DEPENDABOT_AUTHOR_NAME" ]] ; then
   # Skip all builds authored by dependabot
-  echo "🛑 - Build cancelled"
+  echo "🛑 - Build authored by dependabot, cancelling build..."
   exit 0;
 else
   # Proceed with build otherwise
-  echo "✅ - Build can proceed"
+  echo "✅ - Build not authored by dependabot, initiating build..."
   exit 1;
 fi


### PR DESCRIPTION
`dependabot` triggers Vercel preview deployment builds, which eat up reads/writes from Firebase, and counts build minutes for Vercel. We would like to ignore builds authored by `dependabot` to reduce operating costs. Also, we would like to increase the number of PRs from 5 to 10 to catch more updates.