### PR TITLE
[feature]: Add project-specific page

### DIFF
--- a/app/coding/employment/[employmentId]/page.tsx
+++ b/app/coding/employment/[employmentId]/page.tsx
@@ -4,6 +4,7 @@ import { Metadata } from "next";
 import React from "react";
 
 import {
+  EmploymentBackButton,
   EmploymentDateAndDurationContainer,
   EmploymentDurationDisplay,
   EmploymentLogoImage,
@@ -85,6 +86,7 @@ export default async function EmploymentPage({
     <>
       <ImageBackground src={bgUrl} />
       <PageBox>
+        <EmploymentBackButton />
         <Box
           sx={{
             borderRadius: 5,

--- a/app/coding/employment/[employmentId]/page.tsx
+++ b/app/coding/employment/[employmentId]/page.tsx
@@ -8,13 +8,15 @@ import {
   EmploymentDateAndDurationContainer,
   EmploymentDurationDisplay,
   EmploymentLogoImage,
-  EmploymentRoleAndDateContainer,
   EmploymentRoleAndTypeContainer,
 } from "../../../../src/components/employment";
-import { ImageBackground, PageBox } from "../../../../src/components/layout";
+import {
+  ImageBackground,
+  PageBox,
+  ResponsiveSpaceBetweenFlexBox,
+} from "../../../../src/components/layout";
 import { ProjectsGrid } from "../../../../src/components/projects";
-import { BulletPoints } from "../../../../src/components/text";
-import SkillChips from "../../../../src/components/text/SkillChips";
+import { BulletPoints, SkillChips } from "../../../../src/components/text";
 import { Urls } from "../../../../src/const/url";
 import {
   getEmployment,
@@ -108,7 +110,7 @@ export default async function EmploymentPage({
               />
             )}
           </Box>
-          <EmploymentRoleAndDateContainer>
+          <ResponsiveSpaceBetweenFlexBox>
             <EmploymentRoleAndTypeContainer>
               <Typography sx={{ m: 0, fontSize: "1.5rem" }}>
                 {employment.role}
@@ -129,7 +131,7 @@ export default async function EmploymentPage({
                 sx={{ m: 0, fontSize: "1.15rem" }}
               />
             </EmploymentDateAndDurationContainer>
-          </EmploymentRoleAndDateContainer>
+          </ResponsiveSpaceBetweenFlexBox>
           <Typography paragraph>{employment.description}</Typography>
           <BulletPoints points={employment.responsibilities} />
           <SkillChips skills={employment.skills} />

--- a/app/coding/employment/page.tsx
+++ b/app/coding/employment/page.tsx
@@ -24,7 +24,7 @@ export default async function EmploymentsPage(): Promise<React.JSX.Element> {
         <Typography variant="h2" sx={{ mb: 2 }} textAlign="center">
           Coding Employment
         </Typography>
-        <Suspense fallback={<Loading message={"Loading employments..."} />}>
+        <Suspense fallback={<Loading message={"Loading employment..."} />}>
           <EmploymentSelection employments={employments} />
         </Suspense>
       </PageBox>

--- a/app/coding/projects/[projectId]/page.tsx
+++ b/app/coding/projects/[projectId]/page.tsx
@@ -30,7 +30,7 @@ const bgUrl = `${Urls.AssetRoot}/projects/bg/matrix_bg.png`;
 export async function generateStaticParams(): Promise<ProjectPageParams[]> {
   return [
     { projectId: "adaCompliantPointOfSaleSurveyInvitations" },
-    { projectId: "areaguides" },
+    { projectId: "areaGuides" },
     { projectId: "bizcoinSurveysMobileAppV2" },
     { projectId: "bizcoinSurveysPanelistActivationApi" },
     { projectId: "bizcoinSurveysWebPortalV1" },

--- a/app/coding/projects/[projectId]/page.tsx
+++ b/app/coding/projects/[projectId]/page.tsx
@@ -30,7 +30,7 @@ const bgUrl = `${Urls.AssetRoot}/projects/bg/matrix_bg.png`;
 export async function generateStaticParams(): Promise<ProjectPageParams[]> {
   return [
     { projectId: "adaCompliantPointOfSaleSurveyInvitations" },
-    /* { projectId: "areaguides" },
+    { projectId: "areaguides" },
     { projectId: "bizcoinSurveysMobileAppV2" },
     { projectId: "bizcoinSurveysPanelistActivationApi" },
     { projectId: "bizcoinSurveysWebPortalV1" },
@@ -70,7 +70,7 @@ export async function generateStaticParams(): Promise<ProjectPageParams[]> {
     { projectId: "viTelex" },
     { projectId: "vocFeedbackBigCommercePlugin" },
     { projectId: "vocFeedbackShopifyPlugin" },
-    { projectId: "withoutabox" } */
+    { projectId: "withoutabox" },
   ];
 }
 
@@ -159,7 +159,7 @@ export default async function EmploymentPage({
             {getTimeIntervalAsString(startDate, endDate)}
           </Typography>
         </ResponsiveSpaceBetweenFlexBox>
-        <SkillChips skills={skills} />
+        <SkillChips skills={skills} sx={{ mb: 2 }} />
         <ProjectLinks
           projectUrls={projectUrls}
           sx={{ mt: 2, mb: 2 }}

--- a/app/coding/projects/[projectId]/page.tsx
+++ b/app/coding/projects/[projectId]/page.tsx
@@ -1,0 +1,171 @@
+import { Box, Typography } from "@mui/material";
+import { isNil } from "lodash";
+import { Metadata } from "next";
+import React from "react";
+
+import { EmploymentLogoImage } from "../../../../src/components/employment";
+import {
+  FullWidthImage,
+  ImageBackground,
+  PageContainer,
+  ResponsiveSpaceBetweenFlexBox,
+} from "../../../../src/components/layout";
+import { ProjectLinks } from "../../../../src/components/projects";
+import { BulletPoints, SkillChips } from "../../../../src/components/text";
+import { Urls } from "../../../../src/const/url";
+import { getProject } from "../../../../src/dal/api";
+import { Project } from "../../../../src/types/api";
+import { getTimeIntervalAsString } from "../../../../src/util/date";
+
+interface ProjectPageParams {
+  projectId: string;
+}
+
+const bgUrl = `${Urls.AssetRoot}/projects/bg/matrix_bg.png`;
+
+export async function generateStaticParams(): Promise<ProjectPageParams[]> {
+  return [
+    { projectId: "adaCompliantPointOfSaleSurveyInvitations" },
+    /* { projectId: "areaguides" },
+    { projectId: "bizcoinSurveysMobileAppV2" },
+    { projectId: "bizcoinSurveysPanelistActivationApi" },
+    { projectId: "bizcoinSurveysWebPortalV1" },
+    { projectId: "bizcoinSurveysWebPortalV2" },
+    { projectId: "bizrateInsightsHomepage" },
+    { projectId: "brandCaster" },
+    { projectId: "btgApparel" },
+    { projectId: "capacitor" },
+    { projectId: "cloe" },
+    { projectId: "closeOfBooks" },
+    { projectId: "configEditorProfiles" },
+    { projectId: "conopModes" },
+    { projectId: "dailyCashGiveawaySweepstakesAirflowJob" },
+    { projectId: "dataCurationParsers" },
+    { projectId: "dataPipelineDashboardImprovements" },
+    { projectId: "dataPipelineSummary" },
+    { projectId: "defaultHandling" },
+    { projectId: "defiance" },
+    { projectId: "djinDev" },
+    { projectId: "djinDevV2" },
+    { projectId: "fearlessLaMobile" },
+    { projectId: "fearlessLaWebsite" },
+    { projectId: "latticeControlApp" },
+    { projectId: "latticeReportsApi" },
+    { projectId: "letterSuggestions" },
+    { projectId: "listingPlans" },
+    { projectId: "mantisTestHarness" },
+    { projectId: "metrix" },
+    { projectId: "queryCategorizationModuleAnalysis" },
+    { projectId: "queryCategorizationModulesImplementation" },
+    { projectId: "requestTourFlowUnification" },
+    { projectId: "samsungTvHardwareSupport" },
+    { projectId: "simplifiedAuthConsole" },
+    { projectId: "surveyInvitationTemplatizationService" },
+    { projectId: "trackQL" },
+    { projectId: "uscTkdWebsite" },
+    { projectId: "viTelex" },
+    { projectId: "vocFeedbackBigCommercePlugin" },
+    { projectId: "vocFeedbackShopifyPlugin" },
+    { projectId: "withoutabox" } */
+  ];
+}
+
+type GenerateMetadataProps = {
+  params: ProjectPageParams;
+  searchParams: { [key: string]: string | string[] | undefined };
+};
+
+export async function generateMetadata({
+  params,
+}: GenerateMetadataProps): Promise<Metadata> {
+  // read route params
+  const project: Project | null = await getProject(params.projectId);
+  if (isNil(project)) {
+    throw new Error(
+      `Project for projectId ${params.projectId} could not be found`,
+    );
+  }
+  return {
+    title: `d.jin - ${project.name}`,
+  };
+}
+
+export default async function EmploymentPage({
+  params,
+}: {
+  params: ProjectPageParams;
+}): Promise<React.JSX.Element> {
+  const project: Project | null = await getProject(params.projectId);
+  if (isNil(project)) {
+    throw new Error(
+      `Project for projectId ${params.projectId} could not be found`,
+    );
+  }
+  const {
+    name: projectName,
+    startDate,
+    endDate,
+    organization: { name: organizationName, logoUrl },
+    mediaUrl,
+    description,
+    responsibilities,
+    skills,
+    projectUrls,
+    disclaimer,
+  } = project;
+  return (
+    <>
+      <ImageBackground src={bgUrl} />
+      <PageContainer
+        maxWidth="lg"
+        sx={{ backgroundColor: "rgba(255, 255, 255, .90)" }}
+      >
+        <Typography variant="h2" mb={2} textAlign="center">
+          {projectName}
+        </Typography>
+        <FullWidthImage
+          src={mediaUrl}
+          alt={`${projectName} image`}
+          height={1400}
+          width={1600}
+        />
+        <ResponsiveSpaceBetweenFlexBox>
+          <Box display="flex" alignItems="center">
+            {logoUrl && (
+              <EmploymentLogoImage
+                src={logoUrl}
+                alt={`Logo for ${organizationName}`}
+                height={40}
+                width={40}
+              />
+            )}
+            <Typography
+              sx={{
+                m: 0,
+                ml: logoUrl ? 1 : 0,
+                fontSize: "1.5rem",
+              }}
+            >
+              {organizationName}
+            </Typography>
+          </Box>
+          <Typography sx={{ m: 0, fontSize: "1.5rem" }}>
+            {getTimeIntervalAsString(startDate, endDate)}
+          </Typography>
+        </ResponsiveSpaceBetweenFlexBox>
+        <SkillChips skills={skills} />
+        <ProjectLinks
+          projectUrls={projectUrls}
+          sx={{ mt: 2, mb: 2 }}
+        ></ProjectLinks>
+        {disclaimer && (
+          <Typography fontWeight="bold" paragraph>
+            Disclaimer: {disclaimer}
+          </Typography>
+        )}
+        <Typography paragraph>{description}</Typography>
+        <BulletPoints points={responsibilities} />
+      </PageContainer>
+    </>
+  );
+}

--- a/app/coding/projects/[projectId]/page.tsx
+++ b/app/coding/projects/[projectId]/page.tsx
@@ -11,7 +11,11 @@ import {
   ResponsiveSpaceBetweenFlexBox,
 } from "../../../../src/components/layout";
 import { ProjectLinks } from "../../../../src/components/projects";
-import { BulletPoints, SkillChips } from "../../../../src/components/text";
+import {
+  BulletPoints,
+  MuiNextLink,
+  SkillChips,
+} from "../../../../src/components/text";
 import { Urls } from "../../../../src/const/url";
 import { getProject } from "../../../../src/dal/api";
 import { Project } from "../../../../src/types/api";
@@ -105,7 +109,7 @@ export default async function EmploymentPage({
     name: projectName,
     startDate,
     endDate,
-    organization: { name: organizationName, logoUrl },
+    organization: { id: organizationId, name: organizationName, logoUrl },
     mediaUrl,
     description,
     responsibilities,
@@ -139,15 +143,17 @@ export default async function EmploymentPage({
                 width={40}
               />
             )}
-            <Typography
-              sx={{
-                m: 0,
-                ml: logoUrl ? 1 : 0,
-                fontSize: "1.5rem",
-              }}
-            >
-              {organizationName}
-            </Typography>
+            <MuiNextLink href={`/coding/employment/${organizationId}`}>
+              <Typography
+                sx={{
+                  m: 0,
+                  ml: logoUrl ? 1 : 0,
+                  fontSize: "1.5rem",
+                }}
+              >
+                {organizationName}
+              </Typography>
+            </MuiNextLink>
           </Box>
           <Typography sx={{ m: 0, fontSize: "1.5rem" }}>
             {getTimeIntervalAsString(startDate, endDate)}

--- a/app/martialArts/[martialArtsId]/page.tsx
+++ b/app/martialArts/[martialArtsId]/page.tsx
@@ -3,9 +3,12 @@ import { isNil } from "lodash";
 import { Metadata } from "next";
 import React from "react";
 
-import { ImageBackground, PageContainer } from "../../../src/components/layout";
 import {
-  MartialArtsImage,
+  FullWidthImage,
+  ImageBackground,
+  PageContainer,
+} from "../../../src/components/layout";
+import {
   MartialArtsLogoImage,
   MartialArtsStudioGridTile,
 } from "../../../src/components/martialArts";
@@ -121,9 +124,9 @@ export default async function MartialArtsPage({
                     marginInlineEnd: 0,
                   }}
                 >
-                  <MartialArtsImage
+                  <FullWidthImage
                     src={mediaUrl}
-                    alt={`${type}_img`}
+                    alt={`${type} image`}
                     height={1400}
                     width={1600}
                   />

--- a/src/components/employment/EmploymentBackButton.tsx
+++ b/src/components/employment/EmploymentBackButton.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import { Button, Typography } from "@mui/material";
+import { useRouter } from "next/navigation";
+import React from "react";
+
+export const EmploymentBackButton: React.FC = () => {
+  const router = useRouter();
+  const handleClick = () => {
+    router.push("/coding/employment");
+  };
+  return (
+    <Button variant="contained" sx={{ mb: 2 }} onClick={handleClick}>
+      <ChevronLeftIcon />
+      <Typography ml={0.5}>Back to Coding Employment</Typography>
+    </Button>
+  );
+};

--- a/src/components/employment/EmploymentCard.tsx
+++ b/src/components/employment/EmploymentCard.tsx
@@ -7,8 +7,7 @@ import React from "react";
 
 import { Employment } from "../../types/api";
 import { DurationWithOrganizationCardHeader } from "../card";
-import { BulletPoints, IconLink } from "../text";
-import SkillChips from "../text/SkillChips";
+import { BulletPoints, IconLink, SkillChips } from "../text";
 
 interface EmploymentCardProps {
   employment: Employment;

--- a/src/components/employment/EmploymentCard.tsx
+++ b/src/components/employment/EmploymentCard.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import AppsIcon from "@mui/icons-material/Apps";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import { Card, CardContent, CardMedia, Chip, Typography } from "@mui/material";
 import { useRouter } from "next/navigation";
 import React from "react";
 
 import { Employment } from "../../types/api";
 import { DurationWithOrganizationCardHeader } from "../card";
-import { BulletPoints, IconLink, SkillChips } from "../text";
+import { IconLink, SkillChips } from "../text";
 
 interface EmploymentCardProps {
   employment: Employment;
@@ -15,20 +15,20 @@ interface EmploymentCardProps {
 
 export const EmploymentCard: React.FC<EmploymentCardProps> = ({
   employment: {
+    id,
     endDate,
     startDate,
     role,
     organization,
     mediaUrl,
     description,
-    responsibilities,
     skills,
     employmentType,
   },
 }: EmploymentCardProps) => {
   const router = useRouter();
-  const onCardHeaderClick = () =>
-    router.push(`/coding/employment/${organization.id}`);
+  const employmentSpecificPageUrl = `/coding/employment/${id}`;
+  const routeToEmployment = () => router.push(employmentSpecificPageUrl);
   return (
     <Card variant="outlined">
       <DurationWithOrganizationCardHeader
@@ -37,24 +37,43 @@ export const EmploymentCard: React.FC<EmploymentCardProps> = ({
         startDate={startDate}
         endDate={endDate}
         logoUrl={organization.logoUrl}
-        onClick={onCardHeaderClick}
+        onClick={routeToEmployment}
         sx={{
           "&:hover": {
             cursor: "pointer",
           },
         }}
       />
-      <CardMedia image={mediaUrl} sx={{ height: 0, pt: "56.25%" }} />
+      <CardMedia
+        image={mediaUrl}
+        sx={{
+          height: 0,
+          pt: "56.25%",
+          "&:hover": {
+            cursor: "pointer",
+          },
+        }}
+        onClick={routeToEmployment}
+      />
       <CardContent>
         <Chip label={employmentType} size="small" sx={{ mb: 2 }} />
         <IconLink
-          icon={<AppsIcon />}
-          text="Projects"
-          href={`/coding/projects?organizations=${organization.id}`}
-          target="_self"
+          icon={<OpenInNewIcon />}
+          text="Learn More"
+          href={employmentSpecificPageUrl}
         />
-        <Typography paragraph>{description}</Typography>
-        <BulletPoints points={responsibilities} />
+        <Typography
+          paragraph
+          sx={{
+            mt: 2,
+            overflow: "hidden",
+            display: "-webkit-box",
+            WebkitBoxOrient: "vertical",
+            WebkitLineClamp: 8,
+          }}
+        >
+          {description}
+        </Typography>
         <SkillChips skills={skills} />
       </CardContent>
     </Card>

--- a/src/components/employment/index.ts
+++ b/src/components/employment/index.ts
@@ -5,6 +5,5 @@ export { EmploymentTypeSelect } from "./EmploymentTypeSelect";
 export {
   EmploymentDateAndDurationContainer,
   EmploymentLogoImage,
-  EmploymentRoleAndDateContainer,
   EmploymentRoleAndTypeContainer,
 } from "./styled";

--- a/src/components/employment/index.ts
+++ b/src/components/employment/index.ts
@@ -1,3 +1,4 @@
+export { EmploymentBackButton } from "./EmploymentBackButton";
 export { EmploymentDurationDisplay } from "./EmploymentDurationDisplay";
 export { EmploymentSelection } from "./EmploymentSelection";
 export { EmploymentTypeSelect } from "./EmploymentTypeSelect";

--- a/src/components/employment/styled/index.ts
+++ b/src/components/employment/styled/index.ts
@@ -2,5 +2,4 @@ export { EmploymentDateAndDurationContainer } from "./EmploymentDateAndDurationC
 export { EmploymentLogoImage } from "./EmploymentLogoImage";
 export { EmploymentPageHeaderContainer } from "./EmploymentPageHeaderContainer";
 export { EmploymentResumeLink } from "./EmploymentResumeLink";
-export { EmploymentRoleAndDateContainer } from "./EmploymentRoleAndDateContainer";
 export { EmploymentRoleAndTypeContainer } from "./EmploymentRoleAndTypeContainer";

--- a/src/components/hbv/HbvResearchCard.tsx
+++ b/src/components/hbv/HbvResearchCard.tsx
@@ -2,11 +2,10 @@ import DescriptionIcon from "@mui/icons-material/Description";
 import { CardContent, Slide, Typography } from "@mui/material";
 import React from "react";
 
-import { BulletPoints } from "../../components/text";
 import { HbvResearchPaper } from "../../types/api";
 import { DurationWithOrganizationCardHeader } from "../card";
 import { FullWidthCardContainer } from "../layout";
-import SkillChips from "../text/SkillChips";
+import { BulletPoints, SkillChips } from "../text";
 import { HbvResearchCardIconLink } from "./styled";
 
 interface HbvResearchCardProps {

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -2,7 +2,9 @@ export { ImageBackground } from "./ImageBackground";
 export { SiteLayout } from "./SiteLayout";
 export {
   FullWidthCardContainer,
+  FullWidthImage,
   PageBox,
   PageContainer,
+  ResponsiveSpaceBetweenFlexBox,
   VerticallyCenteredPageContainer,
 } from "./styled";

--- a/src/components/layout/styled/FullWidthImage.tsx
+++ b/src/components/layout/styled/FullWidthImage.tsx
@@ -3,7 +3,7 @@
 import { styled } from "@mui/material/styles";
 import Image from "next/image";
 
-export const MartialArtsImage = styled(Image)({
+export const FullWidthImage = styled(Image)({
   maxWidth: "100%",
   height: "auto",
   borderRadius: 30,

--- a/src/components/layout/styled/ResponsiveSpaceBetweenFlexBox.ts
+++ b/src/components/layout/styled/ResponsiveSpaceBetweenFlexBox.ts
@@ -3,12 +3,12 @@
 import { Box } from "@mui/material";
 import { styled } from "@mui/material/styles";
 
-export const EmploymentRoleAndDateContainer = styled(Box)(({ theme }) => ({
+export const ResponsiveSpaceBetweenFlexBox = styled(Box)(({ theme }) => ({
   display: "flex",
   justifyContent: "space-between",
   alignItems: "center",
-  marginTop: theme.spacing(3),
-  marginBottom: theme.spacing(3),
+  marginTop: theme.spacing(2),
+  marginBottom: theme.spacing(2),
   [theme.breakpoints.down("sm")]: {
     flexDirection: "column",
     justifyContent: "normal",

--- a/src/components/layout/styled/index.ts
+++ b/src/components/layout/styled/index.ts
@@ -1,5 +1,7 @@
 export { BackgroundImageBox } from "./BackgroundImageBox";
 export { FullWidthCardContainer } from "./FullWidthCardContainer";
+export { FullWidthImage } from "./FullWidthImage";
 export { PageBox } from "./PageBox";
 export { PageContainer } from "./PageContainer";
+export { ResponsiveSpaceBetweenFlexBox } from "./ResponsiveSpaceBetweenFlexBox";
 export { VerticallyCenteredPageContainer } from "./VerticallyCenteredPageContainer";

--- a/src/components/martialArts/index.ts
+++ b/src/components/martialArts/index.ts
@@ -1,2 +1,2 @@
 export { MartialArtsStudioGridTile } from "./MartialArtsStudioGridTile";
-export { MartialArtsImage, MartialArtsLogoImage } from "./styled";
+export { MartialArtsLogoImage } from "./styled";

--- a/src/components/martialArts/styled/index.ts
+++ b/src/components/martialArts/styled/index.ts
@@ -1,2 +1,1 @@
-export { MartialArtsImage } from "./MartialArtsImage";
 export { MartialArtsLogoImage } from "./MartialArtsLogoImage";

--- a/src/components/projects/ProjectCard.tsx
+++ b/src/components/projects/ProjectCard.tsx
@@ -1,14 +1,10 @@
-import GitHubIcon from "@mui/icons-material/GitHub";
-import LinkIcon from "@mui/icons-material/Link";
-import { Box, Card, CardContent, CardMedia, Typography } from "@mui/material";
-import { isEmpty, isNil, map } from "lodash";
+import { Card, CardContent, CardMedia, Typography } from "@mui/material";
 import React from "react";
 
 import { Project } from "../../types/api";
 import { DurationWithOrganizationCardHeader } from "../card";
-import { StorybookIcon } from "../icons";
-import { BulletPoints, IconLink } from "../text";
-import SkillChips from "../text/SkillChips";
+import { BulletPoints, SkillChips } from "../text";
+import { ProjectLinks } from "./ProjectLinks";
 
 interface ProjectCardProps {
   project: Project;
@@ -38,26 +34,7 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
     />
     <CardMedia image={mediaUrl} sx={{ height: 0, pt: "56.25%" }} />
     <CardContent>
-      {!isNil(projectUrls) && !isEmpty(projectUrls) && (
-        <Box mb={2}>
-          {map(projectUrls, (url: string, urlName: string) => {
-            let icon: React.JSX.Element;
-            switch (urlName) {
-              case "Source Code":
-                icon = <GitHubIcon />;
-                break;
-              case "Storybook":
-                icon = <StorybookIcon />;
-                break;
-              default:
-                icon = <LinkIcon />;
-            }
-            return (
-              <IconLink key={urlName} href={url} text={urlName} icon={icon} />
-            );
-          })}
-        </Box>
-      )}
+      <ProjectLinks projectUrls={projectUrls} sx={{ mb: 2 }}></ProjectLinks>
       {disclaimer && (
         <Typography fontWeight="bold" paragraph>
           Disclaimer: {disclaimer}

--- a/src/components/projects/ProjectCard.tsx
+++ b/src/components/projects/ProjectCard.tsx
@@ -1,10 +1,13 @@
+"use client";
+
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import { Card, CardContent, CardMedia, Typography } from "@mui/material";
+import { useRouter } from "next/navigation";
 import React from "react";
 
 import { Project } from "../../types/api";
 import { DurationWithOrganizationCardHeader } from "../card";
-import { BulletPoints, SkillChips } from "../text";
-import { ProjectLinks } from "./ProjectLinks";
+import { IconLink, SkillChips } from "../text";
 
 interface ProjectCardProps {
   project: Project;
@@ -18,31 +21,61 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
     organization: { name: organizationName, logoUrl },
     mediaUrl,
     description,
-    responsibilities,
+    id,
     skills,
-    projectUrls,
-    disclaimer,
   },
-}: ProjectCardProps) => (
-  <Card variant="outlined">
-    <DurationWithOrganizationCardHeader
-      title={projectName}
-      subtitle={organizationName}
-      startDate={startDate}
-      endDate={endDate}
-      logoUrl={logoUrl}
-    />
-    <CardMedia image={mediaUrl} sx={{ height: 0, pt: "56.25%" }} />
-    <CardContent>
-      <ProjectLinks projectUrls={projectUrls} sx={{ mb: 2 }}></ProjectLinks>
-      {disclaimer && (
-        <Typography fontWeight="bold" paragraph>
-          Disclaimer: {disclaimer}
+}: ProjectCardProps) => {
+  const router = useRouter();
+  const projectSpecificPageUrl = `/coding/projects/${id}`;
+  const routeToProject = () => {
+    router.push(projectSpecificPageUrl);
+  };
+  return (
+    <Card variant="outlined">
+      <DurationWithOrganizationCardHeader
+        title={projectName}
+        subtitle={organizationName}
+        startDate={startDate}
+        endDate={endDate}
+        logoUrl={logoUrl}
+        onClick={routeToProject}
+        sx={{
+          "&:hover": {
+            cursor: "pointer",
+          },
+        }}
+      />
+      <CardMedia
+        image={mediaUrl}
+        sx={{
+          height: 0,
+          pt: "56.25%",
+          "&:hover": {
+            cursor: "pointer",
+          },
+        }}
+        onClick={routeToProject}
+      />
+      <CardContent>
+        <IconLink
+          icon={<OpenInNewIcon />}
+          text="Learn More"
+          href={projectSpecificPageUrl}
+        />
+        <Typography
+          paragraph
+          sx={{
+            mt: 2,
+            overflow: "hidden",
+            display: "-webkit-box",
+            WebkitBoxOrient: "vertical",
+            WebkitLineClamp: 10,
+          }}
+        >
+          {description}
         </Typography>
-      )}
-      <Typography paragraph>{description}</Typography>
-      <BulletPoints points={responsibilities} />
-      <SkillChips skills={skills} />
-    </CardContent>
-  </Card>
-);
+        <SkillChips skills={skills} />
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/projects/ProjectLinks.tsx
+++ b/src/components/projects/ProjectLinks.tsx
@@ -1,0 +1,36 @@
+import GitHubIcon from "@mui/icons-material/GitHub";
+import LinkIcon from "@mui/icons-material/Link";
+import { Box, SxProps, Theme } from "@mui/material";
+import { isEmpty, isNil, map } from "lodash";
+import React from "react";
+
+import { StorybookIcon } from "../icons";
+import { IconLink } from "../text";
+
+interface ProjectLinksProps {
+  projectUrls: Record<string, string> | undefined;
+  sx?: SxProps<Theme>;
+}
+export const ProjectLinks: React.FC<ProjectLinksProps> = ({
+  projectUrls,
+  sx,
+}) => {
+  return isNil(projectUrls) || isEmpty(projectUrls) ? null : (
+    <Box sx={sx}>
+      {map(projectUrls, (url: string, urlName: string) => {
+        let icon: React.JSX.Element;
+        switch (urlName) {
+          case "Source Code":
+            icon = <GitHubIcon />;
+            break;
+          case "Storybook":
+            icon = <StorybookIcon />;
+            break;
+          default:
+            icon = <LinkIcon />;
+        }
+        return <IconLink key={urlName} href={url} text={urlName} icon={icon} />;
+      })}
+    </Box>
+  );
+};

--- a/src/components/projects/index.ts
+++ b/src/components/projects/index.ts
@@ -1,3 +1,4 @@
+export { ProjectLinks } from "./ProjectLinks";
 export { ProjectSelection } from "./ProjectSelection";
 export { ProjectsGrid } from "./ProjectsGrid";
 export { ProjectsPageTitle } from "./styled";

--- a/src/components/text/SkillChips.test.tsx
+++ b/src/components/text/SkillChips.test.tsx
@@ -1,14 +1,14 @@
 import { render } from "@testing-library/react";
 import React from "react";
 
-import SkillChips, { SKILL_CHIP_ROLE } from "./SkillChips";
+import { SKILL_CHIP_ROLE,SkillChips } from "./SkillChips";
 
 describe("SkillChips", () => {
   it("renders an array of skills", () => {
     const inputSkills = ["skill1", "skill2", "skill3"];
     const { getAllByRole } = render(<SkillChips skills={inputSkills} />);
     const actualSkills = getAllByRole(SKILL_CHIP_ROLE).map(
-      (item) => item.textContent
+      (item) => item.textContent,
     );
     expect(actualSkills).toEqual(inputSkills);
   });

--- a/src/components/text/SkillChips.tsx
+++ b/src/components/text/SkillChips.tsx
@@ -1,17 +1,19 @@
-import { Box, Chip } from "@mui/material";
+import { Box, Chip, SxProps, Theme } from "@mui/material";
 import React from "react";
 
 interface SkillChipsProps {
   skills: string[];
+  sx?: SxProps<Theme>;
 }
 
 const SKILL_CHIP_ROLE = "skill";
 
 export const SkillChips: React.FC<SkillChipsProps> = ({
   skills,
+  sx,
 }: SkillChipsProps) => {
   return skills.length < 1 ? null : (
-    <Box display="flex" justifyContent="left" flexWrap="wrap">
+    <Box display="flex" justifyContent="left" flexWrap="wrap" sx={sx}>
       {skills.map((skill) => (
         <Chip
           label={skill}

--- a/src/components/text/SkillChips.tsx
+++ b/src/components/text/SkillChips.tsx
@@ -7,7 +7,9 @@ interface SkillChipsProps {
 
 const SKILL_CHIP_ROLE = "skill";
 
-const SkillChips: React.FC<SkillChipsProps> = ({ skills }: SkillChipsProps) => {
+export const SkillChips: React.FC<SkillChipsProps> = ({
+  skills,
+}: SkillChipsProps) => {
   return skills.length < 1 ? null : (
     <Box display="flex" justifyContent="left" flexWrap="wrap">
       {skills.map((skill) => (

--- a/src/components/text/index.ts
+++ b/src/components/text/index.ts
@@ -5,3 +5,4 @@ export type {
   NextLinkComposedProps,
 } from "./NextLinkComposed";
 export { MuiNextLink, NextLinkComposed } from "./NextLinkComposed";
+export { SkillChips } from "./SkillChips";

--- a/src/dal/api/getProject.ts
+++ b/src/dal/api/getProject.ts
@@ -1,0 +1,13 @@
+import { Project } from "../../types/api";
+import {
+  createGetterByIdForFirestoreQuery,
+  GetterByIdForFirestoreQuery,
+} from "../firestore";
+import { projectsCollection } from "../firestore/collections";
+import { mapProjectDbEntityToProject } from "../mapper";
+
+export const getProject: GetterByIdForFirestoreQuery<Project> =
+  createGetterByIdForFirestoreQuery(
+    projectsCollection,
+    mapProjectDbEntityToProject,
+  );

--- a/src/dal/api/index.ts
+++ b/src/dal/api/index.ts
@@ -8,6 +8,7 @@ import listHolisticOfficeModules from "./listHolisticOfficeModules";
 import listMusicScores from "./listMusicScores";
 import listProjects from "./listProjects";
 export { getEmployment } from "./getEmployment";
+export { getProject } from "./getProject";
 export { listProjectsByOrganizationId } from "./listProjectsByOrganizationId";
 export {
   getMartialArtsStyle,

--- a/src/dal/mapper/mapEmploymentDbEntityToEmployment.ts
+++ b/src/dal/mapper/mapEmploymentDbEntityToEmployment.ts
@@ -8,7 +8,7 @@ import { AsyncMapperFunction } from "../firestore";
 export const mapEmploymentDbEntityToEmployment: AsyncMapperFunction<
   EmploymentDbEntity,
   Employment
-> = async (dbEntity: EmploymentDbEntity): Promise<Employment> => {
+> = async (dbEntity: EmploymentDbEntity, id: string): Promise<Employment> => {
   const {
     organization: organizationRef,
     responsibilities,
@@ -31,6 +31,7 @@ export const mapEmploymentDbEntityToEmployment: AsyncMapperFunction<
     endDate: endDate?.toDate(),
     employmentType: employmentType as EmploymentType,
     responsibilities: responsibilities ?? [],
+    id,
     ...rest,
   };
 };

--- a/src/dal/mapper/mapProjectDbEntityToProject.ts
+++ b/src/dal/mapper/mapProjectDbEntityToProject.ts
@@ -8,7 +8,7 @@ import { AsyncMapperFunction } from "../firestore";
 export const mapProjectDbEntityToProject: AsyncMapperFunction<
   ProjectDbEntity,
   Project
-> = async (dbEntity: ProjectDbEntity): Promise<Project> => {
+> = async (dbEntity: ProjectDbEntity, id: string): Promise<Project> => {
   const {
     startDate,
     endDate,
@@ -30,5 +30,6 @@ export const mapProjectDbEntityToProject: AsyncMapperFunction<
     organization,
     responsibilities: responsibilities ?? [],
     ...rest,
+    id,
   };
 };

--- a/src/types/api/Employment.ts
+++ b/src/types/api/Employment.ts
@@ -2,6 +2,7 @@ import { EmploymentType } from "./EmploymentType";
 import { Organization } from "./Organization";
 
 export interface Employment {
+  id: string;
   organization: Organization;
   mediaUrl: string;
   role: string;

--- a/src/types/api/Project.ts
+++ b/src/types/api/Project.ts
@@ -1,6 +1,7 @@
 import { Organization } from "./Organization";
 
 export interface Project {
+  id: string;
   name: string;
   startDate: Date;
   endDate?: Date;


### PR DESCRIPTION
- Add project-specific pages.
- Truncated employment cards & project cards to line up nicer, linking to respective resource pages
- Employment cards link to employment-specific pages that can link to project-specific pages
- Added a back button for employment-specific pages to go back to employment.
- Refactored common components.
- Added `getProject` API
- Modified employment & project mapping functions to pass back IDs for link construction.