### PR TITLE
[fix]: Fix alignment of title in employment-specific page

### DIFF
--- a/app/coding/employment/[employmentId]/page.tsx
+++ b/app/coding/employment/[employmentId]/page.tsx
@@ -98,7 +98,7 @@ export default async function EmploymentPage({
           mb={2}
         >
           <Box display="flex" flexDirection="column" alignItems="center">
-            <Typography variant="h2" mb={2}>
+            <Typography variant="h2" mb={2} textAlign="center">
               {employment.organization.name}
             </Typography>
             {employment.organization.logoUrl && (


### PR DESCRIPTION
The title of the employment-specific page was text-aligned left, we want to center it. 