### PR TITLE
[fix]: Center title text for martial arts pages

### DIFF
--- a/app/martialArts/[martialArtsId]/page.tsx
+++ b/app/martialArts/[martialArtsId]/page.tsx
@@ -89,7 +89,7 @@ export default async function MartialArtsPage({
           sx={{ backgroundColor: "rgba(255, 255, 255, .75)" }}
         >
           <Box display="flex" flexDirection="column" alignItems="center" mb={2}>
-            <Typography variant="h2" mb={2}>
+            <Typography variant="h2" mb={2} textAlign="center">
               {name}
             </Typography>
             <MartialArtsLogoImage


### PR DESCRIPTION
In mobile, the titles for martial arts pages were not centered. Martial arts page titles are now centered on both desktop and mobile. 