### PR TITLE
[fix]: Titles are now responsive

### DIFF
--- a/app/academic/holisticOffice/page.tsx
+++ b/app/academic/holisticOffice/page.tsx
@@ -105,8 +105,8 @@ export default async function HolisticOfficePage(): Promise<React.JSX.Element> {
           </Grow>
           <ModuleInfoGrid modules={holisticOfficeModules} />
           <LinkSection
-            title="Documentation"
-            description="The documentation provided encompasses a range of project facets beyond the source code itself."
+            title="Documents"
+            description="The documents provided encompasses a range of project facets beyond the source code itself."
             links={documentationLinks}
             icon={<DescriptionIcon />}
           />

--- a/app/academic/reclaimer/page.tsx
+++ b/app/academic/reclaimer/page.tsx
@@ -12,7 +12,7 @@ import {
   VerticallyCenteredPageContainer,
 } from "../../../src/components/layout";
 import { ReclaimerImage } from "../../../src/components/reclaimer";
-import { IconLink, MuiNextLink } from "../../../src/components/text";
+import { IconLink, MuiNextLink, Title } from "../../../src/components/text";
 import { Urls } from "../../../src/const/url";
 
 const bgUrl: string = `${Urls.AssetRoot}/reclaimer/bg/reclaimer_bg.png`;
@@ -31,9 +31,7 @@ export default function ReclaimerPage(): React.JSX.Element {
       <ImageBackground src={bgUrl} />
       <Fade in>
         <VerticallyCenteredPageContainer sx={{ color: lightPurple }}>
-          <Typography variant="h2" textAlign="center">
-            Reclaimer
-          </Typography>
+          <Title variant="h2">Reclaimer</Title>
           <Grow in>
             <ReclaimerImage
               src={gameImg}

--- a/app/coding/employment/[employmentId]/page.tsx
+++ b/app/coding/employment/[employmentId]/page.tsx
@@ -16,7 +16,11 @@ import {
   ResponsiveSpaceBetweenFlexBox,
 } from "../../../../src/components/layout";
 import { ProjectsGrid } from "../../../../src/components/projects";
-import { BulletPoints, SkillChips } from "../../../../src/components/text";
+import {
+  BulletPoints,
+  SkillChips,
+  Title,
+} from "../../../../src/components/text";
 import { Urls } from "../../../../src/const/url";
 import {
   getEmployment,
@@ -98,9 +102,9 @@ export default async function EmploymentPage({
           mb={2}
         >
           <Box display="flex" flexDirection="column" alignItems="center">
-            <Typography variant="h2" mb={2} textAlign="center">
+            <Title variant="h2" mb={2} textAlign="center">
               {employment.organization.name}
-            </Typography>
+            </Title>
             {employment.organization.logoUrl && (
               <EmploymentLogoImage
                 src={employment.organization.logoUrl}
@@ -143,9 +147,9 @@ export default async function EmploymentPage({
           }}
           p={2}
         >
-          <Typography variant="h2" mb={2} textAlign="center">
+          <Title variant="h2" mb={2}>
             Projects
-          </Typography>
+          </Title>
           <ProjectsGrid projects={projects} />
         </Box>
       </PageBox>

--- a/app/coding/employment/page.tsx
+++ b/app/coding/employment/page.tsx
@@ -1,10 +1,10 @@
-import { Typography } from "@mui/material";
 import { Metadata } from "next";
 import React, { Suspense } from "react";
 
 import { EmploymentSelection } from "../../../src/components/employment";
 import { ImageBackground, PageBox } from "../../../src/components/layout";
 import { Loading } from "../../../src/components/loading";
+import { Title } from "../../../src/components/text";
 import { Urls } from "../../../src/const/url";
 import { listEmployments } from "../../../src/dal/api";
 import { Employment } from "../../../src/types/api";
@@ -21,9 +21,9 @@ export default async function EmploymentsPage(): Promise<React.JSX.Element> {
     <>
       <ImageBackground src={bgUrl} />
       <PageBox>
-        <Typography variant="h2" sx={{ mb: 2 }} textAlign="center">
+        <Title variant="h2" sx={{ mb: 2 }}>
           Coding Employment
-        </Typography>
+        </Title>
         <Suspense fallback={<Loading message={"Loading employment..."} />}>
           <EmploymentSelection employments={employments} />
         </Suspense>

--- a/app/coding/projects/[projectId]/page.tsx
+++ b/app/coding/projects/[projectId]/page.tsx
@@ -15,6 +15,7 @@ import {
   BulletPoints,
   MuiNextLink,
   SkillChips,
+  Title,
 } from "../../../../src/components/text";
 import { Urls } from "../../../../src/const/url";
 import { getProject } from "../../../../src/dal/api";
@@ -124,9 +125,9 @@ export default async function EmploymentPage({
         maxWidth="lg"
         sx={{ backgroundColor: "rgba(255, 255, 255, .90)" }}
       >
-        <Typography variant="h2" mb={2} textAlign="center">
+        <Title variant="h2" mb={2} textAlign="center">
           {projectName}
-        </Typography>
+        </Title>
         <FullWidthImage
           src={mediaUrl}
           alt={`${projectName} image`}

--- a/app/martialArts/[martialArtsId]/page.tsx
+++ b/app/martialArts/[martialArtsId]/page.tsx
@@ -13,6 +13,7 @@ import {
   MartialArtsStudioGridTile,
 } from "../../../src/components/martialArts";
 import { ResponsiveGrid } from "../../../src/components/responsiveGrid";
+import { Title } from "../../../src/components/text";
 import { Urls } from "../../../src/const/url";
 import { getMartialArtsStyle } from "../../../src/dal/api";
 import { MartialArtsStudio, MartialArtsStyle } from "../../../src/types/api";
@@ -89,9 +90,9 @@ export default async function MartialArtsPage({
           sx={{ backgroundColor: "rgba(255, 255, 255, .75)" }}
         >
           <Box display="flex" flexDirection="column" alignItems="center" mb={2}>
-            <Typography variant="h2" mb={2} textAlign="center">
+            <Title variant="h2" mb={2}>
               {name}
-            </Typography>
+            </Title>
             <MartialArtsLogoImage
               src={logoUrl}
               alt={`${type}_logo`}
@@ -142,9 +143,9 @@ export default async function MartialArtsPage({
               </Grow>
             </Grid>
           </Grid>
-          <Typography mt={2} mb={2} variant="h2" textAlign="center">
+          <Title mt={2} mb={2} variant="h2">
             Studios
-          </Typography>
+          </Title>
           {studios.length > 0 && (
             <ResponsiveGrid>
               {studios.map((studio: MartialArtsStudio) => (

--- a/app/music/classical/page.tsx
+++ b/app/music/classical/page.tsx
@@ -1,10 +1,10 @@
-import { Typography } from "@mui/material";
 import { Metadata } from "next";
 import React from "react";
 
 import { ImageBackground, PageContainer } from "../../../src/components/layout";
 import { MusicInstrumentTile } from "../../../src/components/music";
 import { ResponsiveGrid } from "../../../src/components/responsiveGrid";
+import { Title } from "../../../src/components/text";
 import { listMusicScores } from "../../../src/dal/api";
 import { MusicInstrument, MusicScore } from "../../../src/types/api";
 
@@ -21,9 +21,9 @@ export default async function ScoresPage(): Promise<React.JSX.Element> {
     <>
       <ImageBackground src={bgUrl} />
       <PageContainer>
-        <Typography variant="h3" mb={2} textAlign="center">
+        <Title variant="h3" mb={2}>
           Music Scores
-        </Typography>
+        </Title>
         {scores.length > 0 &&
           scores.map(({ name, trackUrl, musicInstruments }: MusicScore) =>
             musicInstruments.length < 1 ? null : (

--- a/src/components/edm/styled/EdmTitle.tsx
+++ b/src/components/edm/styled/EdmTitle.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
 
-export const EdmTitle = styled(Typography)(({ theme }) => ({
+import { Title } from "../../text";
+
+export const EdmTitle = styled(Title)(({ theme }) => ({
   marginBottom: theme.spacing(2),
   color: theme.palette.primary.contrastText,
-  textAlign: "center",
 }));
 
 export default EdmTitle;

--- a/src/components/education/styled/EducationPageTitle.tsx
+++ b/src/components/education/styled/EducationPageTitle.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
 
-export const EducationPageTitle = styled(Typography)(({ theme }) => ({
+import { Title } from "../../text";
+
+export const EducationPageTitle = styled(Title)(({ theme }) => ({
   marginBottom: theme.spacing(2),
   color: theme.palette.primary.contrastText,
-  textAlign: "center",
 }));

--- a/src/components/employment/EmploymentSelection.tsx
+++ b/src/components/employment/EmploymentSelection.tsx
@@ -75,7 +75,7 @@ export const EmploymentSelection: React.FC<EmploymentSelectionProps> = ({
         />
         <EmploymentDurationDisplay employments={selectedEmployments} />
       </EmploymentPageHeaderContainer>
-      <EmploymentGrid employments={employments} />
+      <EmploymentGrid employments={selectedEmployments} />
     </>
   );
 };

--- a/src/components/employment/EmploymentSelection.tsx
+++ b/src/components/employment/EmploymentSelection.tsx
@@ -58,7 +58,7 @@ export const EmploymentSelection: React.FC<EmploymentSelectionProps> = ({
   return (
     <>
       <EmploymentPageHeaderContainer>
-        <Typography sx={{ mt: 2, mb: 2 }}>
+        <Typography textAlign="center" mt={2} mb={2}>
           My most current résumé can be obtained{" "}
           <EmploymentResumeLink
             href={resumeUrl}
@@ -73,7 +73,10 @@ export const EmploymentSelection: React.FC<EmploymentSelectionProps> = ({
           selectedEmploymentTypes={selectedEmploymentTypes}
           setSelectedEmploymentTypes={setSelectedEmploymentTypes}
         />
-        <EmploymentDurationDisplay employments={selectedEmployments} />
+        <EmploymentDurationDisplay
+          sx={{ textAlign: "center" }}
+          employments={selectedEmployments}
+        />
       </EmploymentPageHeaderContainer>
       <EmploymentGrid employments={selectedEmployments} />
     </>

--- a/src/components/employment/EmploymentTypeSelect.tsx
+++ b/src/components/employment/EmploymentTypeSelect.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useMediaQuery, useTheme } from "@mui/material";
 import { identity } from "lodash";
 import React from "react";
 
@@ -18,12 +21,14 @@ export const EmploymentTypeSelect: React.FC<EmploymentTypeSelectProps> = ({
   selectedEmploymentTypes,
   setSelectedEmploymentTypes,
 }: EmploymentTypeSelectProps) => {
+  const theme = useTheme();
+  const isMd = useMediaQuery(theme.breakpoints.up("md"));
   const handleChange = (_: React.SyntheticEvent, value: string[]) => {
     setSelectedEmploymentTypes(value.map((v) => v as EmploymentType));
   };
   return (
     <MultiSelect
-      sx={{ width: 330, m: 1 }}
+      sx={{ width: isMd ? 500 : "100%", m: 1 }}
       options={employmentTypes}
       value={selectedEmploymentTypes}
       getOptionLabel={identity}

--- a/src/components/employment/styled/EmploymentPageHeaderContainer.tsx
+++ b/src/components/employment/styled/EmploymentPageHeaderContainer.tsx
@@ -10,5 +10,6 @@ export const EmploymentPageHeaderContainer = styled(Box)(({ theme }) => ({
   backgroundColor: alpha("#fff", 0.75),
   marginTop: theme.spacing(2),
   marginBottom: theme.spacing(2),
+  padding: theme.spacing(2),
   borderRadius: 10,
 }));

--- a/src/components/hbv/styled/HbvTitle.tsx
+++ b/src/components/hbv/styled/HbvTitle.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { styled, Typography } from "@mui/material";
+import { styled } from "@mui/material";
 
-export const HbvTitle = styled(Typography)(({ theme }) => ({
+import { Title } from "../../text";
+
+export const HbvTitle = styled(Title)(({ theme }) => ({
   marginBottom: theme.spacing(2),
-  textAlign: "center",
   color: theme.palette.primary.contrastText,
 }));

--- a/src/components/holisticOffice/styled/HolisticOfficeSectionHeader.tsx
+++ b/src/components/holisticOffice/styled/HolisticOfficeSectionHeader.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
 
-export const HolisticOfficeSectionHeader = styled(Typography)(({ theme }) => ({
+import { Title } from "../../text";
+
+export const HolisticOfficeSectionHeader = styled(Title)(({ theme }) => ({
   marginTop: theme.spacing(2),
   marginBottom: theme.spacing(2),
-  textAlign: "center",
 }));

--- a/src/components/home/AppToolBar.tsx
+++ b/src/components/home/AppToolBar.tsx
@@ -28,7 +28,7 @@ const AppToolBar: React.FC<AppToolBarProps> = ({
   setIsAppDrawerOpen,
 }: AppToolBarProps) => {
   const theme = useTheme();
-  const isDesktop = useMediaQuery(theme.breakpoints.up("md"));
+  const isDesktop = useMediaQuery(theme.breakpoints.up("sm"));
   return (
     <AppBar position={"sticky"}>
       <Toolbar>

--- a/src/components/layout/__snapshots__/SiteLayout.test.tsx.snap
+++ b/src/components/layout/__snapshots__/SiteLayout.test.tsx.snap
@@ -71,7 +71,7 @@ exports[`SiteLayoutPages renders 1`] = `
           class="MuiBox-root css-c66aiw"
         >
           <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-1e6y48t-MuiButtonBase-root-MuiButton-root"
             role="switch"
             tabindex="0"
             type="button"

--- a/src/components/projects/styled/ProjectSelectionContainer.tsx
+++ b/src/components/projects/styled/ProjectSelectionContainer.tsx
@@ -6,7 +6,7 @@ import { styled } from "@mui/material/styles";
 export const ProjectSelectionContainer = styled(Box)(({ theme }) => ({
   borderRadius: 10,
   backgroundColor: alpha("#fff", 0.9),
-  padding: theme.spacing(1),
+  padding: theme.spacing(2),
   marginTop: theme.spacing(2),
   marginBottom: theme.spacing(2),
   display: "flex",

--- a/src/components/projects/styled/ProjectsPageTitle.tsx
+++ b/src/components/projects/styled/ProjectsPageTitle.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { Typography } from "@mui/material";
 import { styled } from "@mui/material/styles";
 
-export const ProjectsPageTitle = styled(Typography)(({ theme }) => ({
+import { Title } from "../../text";
+
+export const ProjectsPageTitle = styled(Title)(({ theme }) => ({
   marginBottom: theme.spacing(2),
   color: theme.palette.primary.contrastText,
   textAlign: "center",

--- a/src/components/text/index.ts
+++ b/src/components/text/index.ts
@@ -6,3 +6,4 @@ export type {
 } from "./NextLinkComposed";
 export { MuiNextLink, NextLinkComposed } from "./NextLinkComposed";
 export { SkillChips } from "./SkillChips";
+export { Title } from "./styled";

--- a/src/components/text/styled/Title.tsx
+++ b/src/components/text/styled/Title.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { Typography } from "@mui/material";
+import { styled } from "@mui/material/styles";
+
+const ultraSmall: number = 300;
+
+export const Title = styled(Typography)({
+  textAlign: "center",
+  wordBreak: "normal",
+  hyphens: "auto",
+  [`@media screen and (max-width: ${ultraSmall}px)`]: {
+    wordBreak: "break-all",
+  },
+});

--- a/src/components/text/styled/index.ts
+++ b/src/components/text/styled/index.ts
@@ -1,0 +1,1 @@
+export { Title } from "./Title";


### PR DESCRIPTION
- Desktop drawer now appears between breakpoints `sm` and `md`
- Titles now word break with `break-all` when there is not sufficient space
- Project selection does not overflow under `sm` breakpoint
- Project selection now has padding of theme spacing `2`. 